### PR TITLE
FIX: PM LED always off

### DIFF
--- a/ELTN-117_Clock.ino
+++ b/ELTN-117_Clock.ino
@@ -184,7 +184,7 @@ void handleTime() {
 }
 
 void handleAlarm() {
-  if(isPM = alarmIsPM && hour == alarmHour && minute == alarmMinute) {
+  if(isPM == alarmIsPM && hour == alarmHour && minute == alarmMinute) {
     playAlarm();
   }
 }


### PR DESCRIPTION
A typo in the conditional assigned false to isPM in most instances.